### PR TITLE
remove updateProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,9 +37,6 @@ class IdyllComponent extends React.PureComponent {
       }
     }
   }
-  updateProps(newProps) {
-    this.props.__handleUpdateProps(newProps);
-  }
 }
 
 module.exports = IdyllComponent;


### PR DESCRIPTION
This removes the special `updateProps` method, instead favoring that it gets injected directly by Idyll on the custom components. This should be merged in sync with https://github.com/idyll-lang/idyll/pull/101